### PR TITLE
exit with exit code 1 when tests fail (fix #3)

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -18,6 +18,8 @@ export async function cliRun(options: TestOptions) {
     mocha.addFile(file)
   }))
 
-  mocha.run() 
-    .on('end', () => codeCoverage.report())
+  mocha.run((failures) => !failures || process.exit(1)) 
+    .on('end', () =>  {
+      codeCoverage.report()
+    })
 }


### PR DESCRIPTION
This addresses issue #3. When there are failed tests, the process should exit with an exit-code of 1 in order to prevent execution of any other scripts after aria-mocha.