### PR TITLE
fix test failing under Windows due to different directory separator

### DIFF
--- a/src/fs/get-test-files.spec.ts
+++ b/src/fs/get-test-files.spec.ts
@@ -34,7 +34,7 @@ describe('getTestFiles', () => {
 
     const result = await getTestFiles('./src/fs', true)
     expect(result.length).equal(1)
-    expect(result.pop()).equal(`./src/fs/${spec}`)
+    expect(result.pop()).equal(['.', 'src', 'fs', spec].join(require('path').sep))
   })
 
   it('should get the test files when file is not typeof file or directory', async () => {


### PR DESCRIPTION
When running `npm test` in aria-mocha itself under Windows, the test `should get the test files when file is not typeof file or directory` fails due to the difference in directory separators (`\` instead of `/`). This is solved by getting the OS's directory separator via node's `fs.sep` and and constructing the expected path string with it.